### PR TITLE
Auto Tare "Deviance" Sensor

### DIFF
--- a/esphome_hx711_smart_scale.yaml
+++ b/esphome_hx711_smart_scale.yaml
@@ -91,6 +91,14 @@ sensor:
     lambda: |-
       return id(auto_tare_difference);
     update_interval: 1s
+
+  - platform: template
+    id: smart_scale_auto_tare_deviance
+    entity_category: "diagnostic"
+    name: "Smart Scale Auto Tare Deviance"
+    lambda: |-
+      return (int((id(smart_scale_hx711_value_raw).state - (id(initial_zero) - id(auto_tare_difference)) ) / 100)) * 100;
+    update_interval: 1s
     
   # sensors imported from home assistant
   - platform: homeassistant
@@ -126,6 +134,8 @@ sensor:
                 - lambda: 'return id(auto_tare_enabled);'
                 # current smart scale value is below approx. 10KG (raw value -275743) aka nobody is standing on the scale
                 - lambda: 'return id(smart_scale_hx711_value).state < 10.0;'
+                # only update if the current deviance is not 0
+                - lambda: 'return id(smart_scale_auto_tare_deviance).state != 0.0;'
             then:
               - if:
                   condition:
@@ -140,7 +150,7 @@ sensor:
                     - lambda: |-
                         id(auto_tare_difference) -= 10;
 
-    
+
   # Mapped value to KG
   - platform: template
     id: smart_scale_hx711_value


### PR DESCRIPTION
# "Auto Tare Deviance" sensor
Adds a new sensor for diagnostic purposes of the auto tare feature.

The sensor shows the difference between the "expected raw value for the 0KG baseline" and the "current raw sensor value". When the "Auto Tare" feature is enabled, this value should slowly approach 0. Note that this will only happen if the deviance is smaller than 10KG, since otherwise the scale will assume a person  is standing on the scale.

If "Auto Tare" is disabled, the user has to manually adjust the initial zero value to set the 0KG baseline.

This PR also adds a condition to the Auto Tare code to avoid adjusting auto_tare_difference if the current deviance is very small, which should reduce the need for network traffic.